### PR TITLE
Improve the clickable comment + map feature by jumping to the map section upon click and automatically closing previous info windows.

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -120,7 +120,7 @@
                     placeholder="Your comment..."></textarea><br>
           <label for="comment-sender-name">Your name [required]:</label>
           <input type="text" id="comment-sender-name" name="comment-sender-name" required
-                placeholder="&lt;first name&gt; &lt;last name&gt;"><br>
+                 placeholder="&lt;first name&gt; &lt;last name&gt;"><br>
           <label for="user-pet-preference">I love</label>
           <select name="user-pet-preference" id="user-pet-preference">
             <option value="cats">cats!</option>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -455,10 +455,7 @@ function addPlaceInfo(comment) {
           mapInfoWindowsDict[comment.placeQueryName] = infoWindow;
           marker.addListener('click', function() {
             infoWindow.open(map, marker);
-            if (openInfoWindow) {
-              openInfoWindow.close();
-            }
-            openInfoWindow = infoWindow;
+            closePreviouslyOpenedInfoWindow(infoWindow);
           });
         });
       }
@@ -477,15 +474,22 @@ function centerOnMarkerAndOpenInfoWindow(placeQueryName) {
     map.setCenter(marker.position);
     const infoWindow = mapInfoWindowsDict[placeQueryName];
     infoWindow.open(map, marker);
-    if (openInfoWindow) {
-      // Close previously opened information window.
-      openInfoWindow.close();
-    }
-    openInfoWindow = infoWindow;
+    closePreviouslyOpenedInfoWindow(infoWindow);
   } catch (err) {
     console.log('Could not center on marker/open the information window:' +
                 ` ${err.message}`);
   }
+}
+
+/**
+ * Closes the previously opened information window upon a new window being
+ * opened, and makes a note of the newly opened information window.
+ */
+function closePreviouslyOpenedInfoWindow(newlyOpenedInfoWindow) {
+  if (openInfoWindow) {
+    openInfoWindow.close();
+  }
+  openInfoWindow = newlyOpenedInfoWindow;
 }
 
 /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -24,6 +24,7 @@ let map;
 let isMapLibrariesLoaded = false;
 let mapMarkersDict;
 let mapInfoWindowsDict;
+let openInfoWindow;
 const mapInitialZoom = 12;
 const APIKey = config.APIKey;
 const IMAGE_UPLOAD_NOT_SUPPORTED_DEPLOYED = 'notSupportedOnDeployedServer';
@@ -453,7 +454,11 @@ function addPlaceInfo(comment) {
           });
           mapInfoWindowsDict[comment.placeQueryName] = infoWindow;
           marker.addListener('click', function() {
-              infoWindow.open(map, marker);
+            infoWindow.open(map, marker);
+            if (openInfoWindow) {
+              openInfoWindow.close();
+            }
+            openInfoWindow = infoWindow;
           });
         });
       }
@@ -472,6 +477,11 @@ function centerOnMarkerAndOpenInfoWindow(placeQueryName) {
     map.setCenter(marker.position);
     const infoWindow = mapInfoWindowsDict[placeQueryName];
     infoWindow.open(map, marker);
+    if (openInfoWindow) {
+      // Close previously opened information window.
+      openInfoWindow.close();
+    }
+    openInfoWindow = infoWindow;
   } catch (err) {
     console.log('Could not center on marker/open the information window:' +
                 ` ${err.message}`);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -454,8 +454,7 @@ function addPlaceInfo(comment) {
           });
           mapInfoWindowsDict[comment.placeQueryName] = infoWindow;
           marker.addListener('click', function() {
-            infoWindow.open(map, marker);
-            closePreviouslyOpenedInfoWindow(infoWindow);
+            closePreviousAndOpenNewInfoWindow(infoWindow, marker);
           });
         });
       }
@@ -473,8 +472,7 @@ function centerOnMarkerAndOpenInfoWindow(placeQueryName) {
     const marker = mapMarkersDict[placeQueryName];
     map.setCenter(marker.position);
     const infoWindow = mapInfoWindowsDict[placeQueryName];
-    infoWindow.open(map, marker);
-    closePreviouslyOpenedInfoWindow(infoWindow);
+    closePreviousAndOpenNewInfoWindow(infoWindow, marker);
   } catch (err) {
     console.log('Could not center on marker/open the information window:' +
                 ` ${err.message}`);
@@ -482,14 +480,19 @@ function centerOnMarkerAndOpenInfoWindow(placeQueryName) {
 }
 
 /**
- * Closes the previously opened information window upon a new window being
- * opened, and makes a note of the newly opened information window.
+ * Closes the previously opened information window; opens and makes a note of
+ * the newly opened information window.
  */
-function closePreviouslyOpenedInfoWindow(newlyOpenedInfoWindow) {
+function closePreviousAndOpenNewInfoWindow(newInfoWindowToOpen, marker) {
+  // Opening the window (re-)centers the map on the window.
+  newInfoWindowToOpen.open(map, marker);
+  if (newInfoWindowToOpen === openInfoWindow) {
+    return;
+  }
   if (openInfoWindow) {
     openInfoWindow.close();
   }
-  openInfoWindow = newlyOpenedInfoWindow;
+  openInfoWindow = newInfoWindowToOpen;
 }
 
 /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -242,6 +242,7 @@ async function addCommentHistory(pageId) {
       centerOnMarkerAndOpenInfoWindow(comments[i].placeQueryName);
     };
     clickableComment.innerText = formattedComment;
+    clickableComment.href = '#map';
     commentItem.appendChild(clickableComment);
     commentHistoryHTML.appendChild(commentItem);
     commentHistoryHTML.appendChild(document.createElement('br'));


### PR DESCRIPTION
Improve the clickable comment + map feature by jumping to the map section upon click and automatically closing previous info windows:
- Jump to the map section (and show the corresponding marker and information window), when the user clicks on a comment in the comment history.
- Automatically close the previously opened information window, when the user opens a new information window, either by clicking on another marker on the map or by clicking on another comment in the comment history.

The server is live at: https://feiyangyu-step-2020-v2.ue.r.appspot.com