### PR TITLE
Implement FindMeetingQuery to find all available meeting time ranges for a set of attendees, given existing events.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -109,6 +109,13 @@ public final class FindMeetingQuery {
             TimeRange.fromStartDuration(availableTimeRangeStart, availableDuration)
         );
       }
+
+      // Find the potential, next block of available time sandwiched between an ending and a
+      // starting {@code TimeRange}.
+      // (We can safely increment both pointers without missing any available time, because
+      //  we had the guarantee that no other existing {@code TimeRange} can be found between
+      //  the current ending and starting {@code TimeRange}.)
+      startOrderedPointer++;
       endOrderedPointer++;
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -28,26 +28,26 @@ import java.util.Set;
 public final class FindMeetingQuery {
 
   /**
-  * Finds the available {@code TimeRange} for a set of attendees to satisfy a meeting
-  * {@code request}, given some existing {@code events} and their respective attendees.
-  * The resultant {@code TimeRange} do not overlap with one another and cover all possible
-  * gaps between the existing {@code events}. These {@code TimeRange} have the same length as
-  * or are longer than the requested meeting duration.
-  * First extracts the existing {@code TimeRange} that correspond to {@code Event} having
-  * overlapping attendees with the {@code request}; we only need to avoid conflicting with
-  * those {@code TimeRange} that involve attendees contained in the {@code request}.
-  * Then finds the available {@code TimeRange} sandwiched between an existing, occupied
-  * {@code TimeRange} and the next {@code TimeRange}.
-  *
-  * @param events Existing events that each occupy some {@code TimeRange}.
-  * @param request A meeting request for some mandatory and optional attendees and a duration.
-  * @return All available {@code TimeRange} that satisfy the meeting request.
-  */
+   * Finds the available {@code TimeRange} for a set of attendees to satisfy a meeting
+   * {@code request}, given some existing {@code events} and their respective attendees.
+   * The resultant {@code TimeRange} do not overlap with one another and cover all possible
+   * empty gaps in the existing {@code events}. These {@code TimeRange} have the same length as
+   * or are longer than the requested meeting duration.
+   * -- First extracts the existing {@code TimeRange} of those {@code Event} that include any
+   * attendees mentioned in the {@code request}; we only need to avoid conflicting with
+   * those {@code TimeRange} that involve attendees mentioned in the {@code request}.
+   * -- Then finds the available {@code TimeRange} sandwiched between two already-occupied
+   * {@code TimeRange}.
+   *
+   * @param events Existing events that each occupy some {@code TimeRange}.
+   * @param request A meeting request for some mandatory and optional attendees and a duration.
+   * @return All available {@code TimeRange} that satisfy the meeting request.
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     Collection<String> attendees = request.getAttendees();
     long requestedDuration = request.getDuration();
 
-    if (Long.compare(requestedDuration, TimeRange.WHOLE_DAY.duration()) > 0) {
+    if (requestedDuration > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();
     } else if (events.isEmpty() || attendees.isEmpty()) {
       return Arrays.asList(TimeRange.WHOLE_DAY);
@@ -60,8 +60,8 @@ public final class FindMeetingQuery {
   }
 
   /**
-  * Finds the {@code TimeRange} of {@code events} that include the given {@code attendees}.
-  */
+   * Finds the {@code TimeRange} of {@code events} that include the given {@code attendees}.
+   */
   private Collection<TimeRange> getConcernedAttendeesTimeRangesFromEvents(
       Collection<Event> events,
       Collection<String> attendees) {
@@ -75,10 +75,14 @@ public final class FindMeetingQuery {
   }
 
   /**
-  * Finds the available {@code TimeRange} having at least a length of {@code requestedDuration},
-  * given some already occupied {@code TimeRange}.
-  * The resultant list of available {@code TimeRange} is sorted in ascending chronological order.
-  */
+   * Finds the available {@code TimeRange} having at least a length of {@code requestedDuration},
+   * given some already occupied {@code TimeRange}.
+   *
+   * @param occupiedTimeRanges A collection of {@code TimeRange} that are considered occupied and
+   *   need to be avoided.
+   * @param requestedDuration The requested length of the available {@code TimeRange} to find.
+   * @return A list of all available {@code TimeRange} sorted in ascending chronological order.
+   */
   private List<TimeRange> getAvailabeTimeRanges(Collection<TimeRange> occupiedTimeRanges,
       long requestedDuration) {
     if (occupiedTimeRanges.isEmpty()) {
@@ -111,8 +115,8 @@ public final class FindMeetingQuery {
   }
 
   /**
-  * Sorts {@code timeRanges} based on the specified {@code sortOrder}.
-  */
+   * Sorts {@code timeRanges} based on the specified {@code sortOrder}.
+   */
   private List<TimeRange> getOrderedTimeRanges(Collection<TimeRange> timeRanges,
       Comparator<TimeRange> sortOrder) {
     List<TimeRange> orderedTimeRanges = new LinkedList<>(timeRanges);
@@ -121,17 +125,16 @@ public final class FindMeetingQuery {
   }
 
   /**
-  * Find available {@code TimeRange} by looking at the available time between the end of one
-  * occupied {@code TimeRange} and the start of the next occupied {@code TimeRange}:
-  *   |----ending {@code TimeRange}----| available time |----starting {@code TimeRange}----|
-  *
-  * @param requestedDuration The requested length of the overlapping, available {@code TimeRange}
-  *   to find.
-  * @param startOrderedTimeRanges A start-time ordered list of occupied {@TimeRange}.
-  * @param endOrderedTimeRanges An end-time ordered list of occupied {@TimeRange}.
-  * @param availableTimeRanges A list of available {@code TimeRange} that avoid the already
-  *   occupied {@code TimeRange}.
-  */
+   * Find available {@code TimeRange} by looking at the available time between the end of one
+   * occupied {@code TimeRange} and the start of the next occupied {@code TimeRange}:
+   *   |----ending {@code TimeRange}----| available time |----starting {@code TimeRange}----|
+   *
+   * @param requestedDuration The requested length of the available {@code TimeRange} to find.
+   * @param startOrderedTimeRanges A start-time ordered list of occupied {@TimeRange}.
+   * @param endOrderedTimeRanges An end-time ordered list of occupied {@TimeRange}.
+   * @param availableTimeRanges A list of available {@code TimeRange} that avoid the already
+   *     occupied {@code TimeRange}.
+   */
   private void findAndAddGapsInOccupiedTimeRanges(long requestedDuration,
       List<TimeRange> startOrderedTimeRanges,
       List<TimeRange> endOrderedTimeRanges,
@@ -183,9 +186,9 @@ public final class FindMeetingQuery {
   }
 
   /**
-  * If a [start, end) represented {@code TimeRange} has a sufficient duration, adds it to the
-  * set of available {@code TimeRange}.
-  */
+   * If a [start, end) represented {@code TimeRange} has a sufficient duration, adds it to the
+   * set of available {@code TimeRange}.
+   */
   private void checkDurationAndAddAvailableTimeRange(long requestedDuration, int start, int end,
       Collection<TimeRange> availableTimeRanges) {
     if (requestedDuration <= end - start) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,113 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public final class FindMeetingQuery {
+
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    Collection<TimeRange> availableTimeRanges = new ArrayList<>();
+    Set<String> attendees = new HashSet<>(request.getAttendees());
+    long duration = request.getDuration();
+
+    if (Long.compare(duration, TimeRange.WHOLE_DAY.duration()) > 0) {
+      // If the requested duration is longer than the {@code WHOLE_DAY}, there can't be any
+      // {@code TimeRange} that satisfies the {@code request}.
+      return Arrays.asList();
+    } else if (events.isEmpty() || attendees.isEmpty()) {
+      // If there are no existing {@code Event} or mandatory attendees, the {@code WHOLE_DAY}
+      // satisfies the request.
+      return Arrays.asList(TimeRange.WHOLE_DAY);
+    }
+
+    // Find existing {@code TimeRange} that correspond to {@code Event} having overlapping
+    // attendees with the {@code request}.
+    Collection<TimeRange> relevantTimeRanges = new HashSet<>();
+    for (Event event : events) {
+      // Make a shallow copy of the original set of attendees.
+      Set<String> overlappingAttendees = new HashSet<>(event.getAttendees());
+      overlappingAttendees.retainAll(attendees);
+      if (!overlappingAttendees.isEmpty()) {
+        relevantTimeRanges.add(event.getWhen());
+      }
+    }
+    if (relevantTimeRanges.isEmpty()) {
+      // If there are no existing {@code Event} that contain overlapping attendees with the meeting
+      // request, the {@code WHOLE_DAY} satisfies the {@code request}.
+      return Arrays.asList(TimeRange.WHOLE_DAY);
+    }
+
+    // Sort the relevant {@code TimeRange} based on their start and end times respectively.
+    List<TimeRange> startOrderedTimeRanges = new ArrayList<>(relevantTimeRanges);
+    List<TimeRange> endOrderedTimeRanges = new ArrayList<>(relevantTimeRanges);
+    Collections.sort(startOrderedTimeRanges, TimeRange.ORDER_BY_START);
+    Collections.sort(endOrderedTimeRanges, TimeRange.ORDER_BY_END);
+
+    // Add the available {@code TimeRange} before the first existing {@code TimeRange}, if
+    // said available {@code TimeRange} is long enough.
+    TimeRange firstStartingTimeRange = startOrderedTimeRanges.get(0);
+    if (Long.compare(duration, firstStartingTimeRange.start() - TimeRange.START_OF_DAY) <= 0) {
+      availableTimeRanges.add(TimeRange.fromStartEnd(TimeRange.START_OF_DAY,
+                                                     firstStartingTimeRange.start(),
+                                                     false));
+    }
+
+    // Find available {@code TimeRange} by looking at the available time between one ending
+    // {@code TimeRange} and the immediately following starting {@code TimeRange}.
+    int availableTimeRangeStart;
+    int availableTimeRangeEnd;
+    int startOrderedPointer = 0;
+    int endOrderedPointer = 0;
+    while (startOrderedPointer < startOrderedTimeRanges.size() &&
+        endOrderedPointer < endOrderedTimeRanges.size()) {
+      TimeRange endingTimeRange = endOrderedTimeRanges.get(endOrderedPointer);
+      TimeRange startingTimeRange = startOrderedTimeRanges.get(startOrderedPointer);
+
+      // There is no available time after the current ending {@code TimeRange} and before the
+      // immediately following starting {@code TimeRange}.
+      if (endingTimeRange.overlaps(startingTimeRange)) {
+        startOrderedPointer++;
+        continue;
+      }
+      // There is another {@code TimeRange} that ends later than the current ending
+      // {@code TimeRange} + before the immediately following, starting {@code TimeRange}.
+      // (Since there exists a {@code TimeRange} starting later than the current ending
+      //  {@code TimeRange}, there must be other {@code TimeRange} ending even later. Therefore,
+      //  the {@code endOrderedPointer} is guaranteed to not go out of range.)
+      TimeRange nextEndingTimeRange = endOrderedTimeRanges.get(endOrderedPointer + 1);
+      if (nextEndingTimeRange.end() <= startingTimeRange.start()) {
+        endOrderedPointer++;
+        continue;
+      }
+
+      // At this point, we have:
+      //    |----ending {@code TimeRange}----| available time |----starting {@code TimeRange}----|
+      availableTimeRangeStart = endingTimeRange.end();
+      availableTimeRangeEnd = startingTimeRange.start();
+      int availableDuration = availableTimeRangeEnd - availableTimeRangeStart;
+      if (Long.compare(duration, availableDuration) <= 0) {
+        availableTimeRanges.add(
+            TimeRange.fromStartDuration(availableTimeRangeStart, availableDuration)
+        );
+      }
+      endOrderedPointer++;
+    }
+
+    // Add the available {@code TimeRange} that comes after the last existing {@code TimeRange},
+    // if said available {@code TimeRange} is long enough.
+    TimeRange lastEndingTimeRange = endOrderedTimeRanges.get(endOrderedTimeRanges.size() - 1);
+    if (Long.compare(duration, TimeRange.END_OF_DAY - lastEndingTimeRange.end() + 1) <= 0) {
+      availableTimeRanges.add(TimeRange.fromStartEnd(lastEndingTimeRange.end(),
+                                                     TimeRange.END_OF_DAY,
+                                                     true));
+    }
+
+    return availableTimeRanges;
   }
 }


### PR DESCRIPTION
Implement FindMeetingQuery to find all available meeting time ranges for a set of attendees, given existing events [Pass the provided tests]:
- Handle edge cases, such as when there are no attendees, or existing events.
- Find the available time ranges by examining the available time between (1) an ending time range occupied by an existing event & (2) the immediately following, starting time range occupied by another existing event.
- Check two additional time ranges: one occurring before the first existing event, and one occurring after the last existing event.