### PR TITLE
 Write tests for the optional attendees feature in finding available meeting time ranges. Implement the optional attendee feature.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -73,15 +73,11 @@ public final class FindMeetingQuery {
     if (!attendees.isEmpty()) {
       Collection<TimeRange> occupiedTimeRanges =
           getConcernedAttendeesTimeRangesFromEvents(events, attendees);
-      List<TimeRange> availableTimeRangesForMandatoryAttendees =
-          getAvailableTimeRanges(occupiedTimeRanges, requestedDuration);
-      return availableTimeRangesForMandatoryAttendees;
+      return getAvailableTimeRanges(occupiedTimeRanges, requestedDuration);
     } else {
       Collection<TimeRange> optionalOccupiedTimeRanges =
           getConcernedAttendeesTimeRangesFromEvents(events, optionalAttendees);
-      List<TimeRange> availableTimeRangesForOptionalAttendees =
-          getAvailableTimeRanges(optionalOccupiedTimeRanges, requestedDuration);
-      return availableTimeRangesForOptionalAttendees;
+      return getAvailableTimeRanges(optionalOccupiedTimeRanges, requestedDuration);
     }
   }
 


### PR DESCRIPTION
**Construct the optional attendees feature**: If one or more time ranges satisfy the meeting request for both mandatory and optional attendees, return all of those time ranges; if not, return all available time ranges that satisfy the meeting request for mandatory attendees.
- Write 5 tests for the expected behavior of the new optional attendees feature, as outlined in the walkthrough.
    One test details an exception for the algorithm: When there are no mandatory attendees, the algorithm finds all available time ranges that satisfy the request for optional attendees. It may be possible that no time ranges can satisfy such request. Thus, no time ranges are returned.
- Implement the optional attendees feature in `FindMeetingQuery` using `LinkedList` and `ListIterator` for efficient O(1) access.

1. Find the existing, occupied time ranges for the mandatory and optional attendees, respectively;
2. Find the available time ranges for the mandatory and optional attendees, respectively;
3. Find the overlapping, available time ranges for the mandatory and optional attendees.