### PR TITLE
Implement alternative algorithm for finding gaps in occupied schedules for mandatory and optional attendees.

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -46,17 +46,17 @@ public final class FindMeetingQuery {
    * @return All available {@code TimeRange} that satisfy the meeting request.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    Collection<String> attendees = request.getAttendees();
+    Collection<String> mandatoryAttendees = request.getAttendees();
     Collection<String> optionalAttendees = request.getOptionalAttendees();
     long requestedDuration = request.getDuration();
 
     if (requestedDuration > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();
-    } else if (events.isEmpty() || (attendees.isEmpty() && optionalAttendees.isEmpty())) {
+    } else if (events.isEmpty() || (mandatoryAttendees.isEmpty() && optionalAttendees.isEmpty())) {
       return Arrays.asList(TimeRange.WHOLE_DAY);
     }
 
-    Collection<String> allAttendees = new HashSet<>(attendees);
+    Collection<String> allAttendees = new HashSet<>(mandatoryAttendees);
     allAttendees.addAll(optionalAttendees);
     Collection<TimeRange> allOccupiedTimeRanges =
         getConcernedAttendeesTimeRangesFromEvents(events, allAttendees);
@@ -66,9 +66,9 @@ public final class FindMeetingQuery {
       return availableTimeRangesForAllAttendees;
     }
 
-    if (!attendees.isEmpty()) {
+    if (!mandatoryAttendees.isEmpty()) {
       Collection<TimeRange> occupiedTimeRanges =
-          getConcernedAttendeesTimeRangesFromEvents(events, attendees);
+          getConcernedAttendeesTimeRangesFromEvents(events, mandatoryAttendees);
       return getAvailableTimeRanges(occupiedTimeRanges, requestedDuration);
     } else {
       Collection<TimeRange> optionalOccupiedTimeRanges =

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -161,30 +161,22 @@ public final class FindMeetingQuery {
   private void findAndAddGapsInOccupiedTimeRanges(long requestedDuration,
       List<TimePoint> orderedTimePoints,
       Collection<TimeRange> availableTimeRanges) {
-    int index = 1;
-    int unendedTimeRange = 1;
-
-    while (index < orderedTimePoints.size()) {
+    int unendedTimeRange = 0;
+    for (int index = 0; index < orderedTimePoints.size(); index++) {
       // Construct a continuously occupied range of time, which needs to be skipped. Such
       // continuously occupied range of time would contain an equal number of start and end
       // {@code TimePoint}. This occupied range may look like (TR stands for {@code TimeRange}):
       //    [start of TR1, start of TR2, end of TR1, start of TR3, end of TR3, end of TR2]
       // Available time occurs after the continuously occupied ranges of time.
-      if (unendedTimeRange > 0) {
-        if (orderedTimePoints.get(index).isTimeRangeStart()) {
-          unendedTimeRange++;
-        } else {
-          unendedTimeRange--;
-        }
-      } else {
-        int availableTimeRangeStart = orderedTimePoints.get(index - 1).getTime();
-        int availableTimeRangeEnd = orderedTimePoints.get(index).getTime();
+      int _ = orderedTimePoints.get(index).isTimeRangeStart() ?
+          unendedTimeRange++ : unendedTimeRange--;
+      if (unendedTimeRange == 0 && index + 1 < orderedTimePoints.size()) {
+        int availableTimeRangeStart = orderedTimePoints.get(index).getTime();
+        int availableTimeRangeEnd = orderedTimePoints.get(index + 1).getTime();
         checkDurationAndAddAvailableTimeRange(requestedDuration,
                                               availableTimeRangeStart, availableTimeRangeEnd,
                                               availableTimeRanges);
-        unendedTimeRange = 1;
       }
-      index++;
     }
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -73,15 +73,11 @@ public final class FindMeetingQuery {
     if (!attendees.isEmpty()) {
       Collection<TimeRange> occupiedTimeRanges =
           getConcernedAttendeesTimeRangesFromEvents(events, attendees);
-      List<TimeRange> availableTimeRangesForMandatoryAttendees =
-          getAvailableTimeRanges(occupiedTimeRanges, requestedDuration);
-      return availableTimeRangesForMandatoryAttendees;
+      return getAvailableTimeRanges(occupiedTimeRanges, requestedDuration);
     } else {
       Collection<TimeRange> optionalOccupiedTimeRanges =
           getConcernedAttendeesTimeRangesFromEvents(events, optionalAttendees);
-      List<TimeRange> availableTimeRangesForOptionalAttendees =
-          getAvailableTimeRanges(optionalOccupiedTimeRanges, requestedDuration);
-      return availableTimeRangesForOptionalAttendees;
+      return getAvailableTimeRanges(optionalOccupiedTimeRanges, requestedDuration);
     }
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -107,8 +107,7 @@ public final class FindMeetingQuery {
       return Arrays.asList(TimeRange.WHOLE_DAY);
     }
 
-    List<TimePoint> timePoints = getTimePointsFromTimeRanges(occupiedTimeRanges);
-    List<TimePoint> orderedTimePoints = getOrderedTimePoints(timePoints);
+    List<TimePoint> orderedTimePoints = getOrderedTimePointsFromTimeRanges(occupiedTimeRanges);
     List<TimeRange> availableTimeRanges = new LinkedList<>();
 
     // Potentially add the {@code TimeRange} before the first occupied {@code TimeRange}.
@@ -127,21 +126,15 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Finds the start and end {@code TimePoint} of {@code timeRanges}.
+   * Finds the start and end {@code TimePoint} of {@code timeRanges}, and sorts them based on
+   * ascending chronological order.
    */
-  private List<TimePoint> getTimePointsFromTimeRanges(Collection<TimeRange> timeRanges) {
+  private List<TimePoint> getOrderedTimePointsFromTimeRanges(Collection<TimeRange> timeRanges) {
     List<TimePoint> timePoints = new ArrayList<>(2 * timeRanges.size());
     for (TimeRange timeRange : timeRanges) {
       timePoints.add(new TimePoint(timeRange.start(), true));
       timePoints.add(new TimePoint(timeRange.end(), false));
     }
-    return timePoints;
-  }
-
-  /**
-   * Sorts the start or end{@code TimePoint} based on ascending chronological order.
-   */
-  private List<TimePoint> getOrderedTimePoints(List<TimePoint> timePoints) {
     Collections.sort(timePoints, TimePoint.ORDER_BY_TIME);
     return timePoints;
   }
@@ -168,8 +161,7 @@ public final class FindMeetingQuery {
       // {@code TimePoint}. This occupied range may look like (TR stands for {@code TimeRange}):
       //    [start of TR1, start of TR2, end of TR1, start of TR3, end of TR3, end of TR2]
       // Available time occurs after the continuously occupied ranges of time.
-      int _ = orderedTimePoints.get(index).isTimeRangeStart() ?
-          unendedTimeRange++ : unendedTimeRange--;
+      unendedTimeRange += orderedTimePoints.get(index).isTimeRangeStart() ? +1 : -1;
       if (unendedTimeRange == 0 && index + 1 < orderedTimePoints.size()) {
         int availableTimeRangeStart = orderedTimePoints.get(index).getTime();
         int availableTimeRangeEnd = orderedTimePoints.get(index + 1).getTime();

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimePoint.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimePoint.java
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import java.util.Comparator;
+
+/**
+ * Class representing either the start or end time point for a {@code TimeRange}.
+ */
+public class TimePoint {
+  /**
+    * A comparator for sorting {@TimePoint} based on the time they represent.
+    */
+  public static final Comparator<TimePoint> ORDER_BY_TIME = new Comparator<TimePoint>() {
+    @Override
+    public int compare(TimePoint a, TimePoint b) {
+      return Integer.compare(a.time, b.time);
+    }
+  };
+  private final int time;
+  private final boolean isTimeRangeStart;
+
+  public TimePoint(int inputTime, boolean inputIsTimeRangeStart) {
+    this.time = inputTime;
+    this.isTimeRangeStart = inputIsTimeRangeStart;
+  }
+
+  /**
+    * Returns the time represented by the time point.
+    */
+  public int time() {
+    return time;
+  }
+
+  /**
+    * Returns whether this time point is the start of a {@code TimeRange}. A time point can
+    * either be the start or the end of a {@code TimeRange}.
+    */
+  public boolean isTimeRangeStart() {
+    return isTimeRangeStart;
+  }
+}

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimePoint.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimePoint.java
@@ -40,7 +40,7 @@ public class TimePoint {
   /**
     * Returns the time represented by the time point.
     */
-  public int time() {
+  public int getTime() {
     return time;
   }
 


### PR DESCRIPTION
Implement an alternative algorithm, for finding gaps in occupied schedules for mandatory and optional attendees:
- Follow a similar code structure as pull request #13.
- Implement alternative implementation that has the same time complexity, but better readability. The main method changed is `findAndAddGapsInOccupiedTimeRanges`. The basic logic of the new algorithm is:

1. Obtain the start and end `TimePoint`s of occupied `TimeRange`s.
2. Construct continuously occupied ranges of time by combining start and end `TimePoint`s. Conceptually, this is laying out the occupied `TimeRange`s on a "time axis" while the occupied `TimeRange`s may or may not overlap with one another. We construct a "time axis" with all occupied ranges marked.
3. Find gaps between occupied ranges on the "time axis".